### PR TITLE
Add Pipenv support and updates to READMEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,7 @@ ENV/
 
 # IntelliJ IDEs such as PyCharm
 .idea
+
+# Pipenv
+Pipfile.lock
+.venv

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+ipython = "*"
+
+[packages]
+cffi = "*"
+cython = "*"
+pybind11 = "*"

--- a/Prerequisites.md
+++ b/Prerequisites.md
@@ -47,15 +47,27 @@ We recommend using
 
 
 ## Python and Other Tools
-By far the easiest way to get all of the tools installed and setup is by using the Anaconda Python
+
+### Pipenv
+[Pipenv](https://github.com/pypa/pipenv) is an easy way to install compatible versions of `cffi`, `cython`, and 
+`pybind11`.  Once `pipenv` in installed, these other packages can be installed in a virtual environment using:
+```shell script
+pipenv install
+```  
+
+Then this Python virtual environment can be entered using:
+```shell script
+pipenv shell
+```
+
+### Anaconda Python
+Another easy way to get all of the tools installed and setup is by using the Anaconda Python
 distribution.  This is a free distribution of Python available for Windows, Mac OS X, and Linux which
 comes with a couple hundred of the most common and useful Python modules pre-installed including Cython
 and CFFI.  It also comes with the ``conda`` package manager which can be used to install additional
 tools such as SWIG.
 
-## Anaconda Python
-Download the latest version of [Anaconda](https://www.continuum.io/downloads).  Either the Python 3.6 or
-Python 2.7 version should be fine, but we recommend the Python 3.6 version.
+Download the latest version of [Anaconda](https://www.continuum.io/downloads).  We recommend Python 3.6 or newer.
 
 Install Anaconda per the instructions and let it modify your .bashrc, .bash_profile, or path accordingly.
 NOTE: Do not use ``sudo`` to install Anaconda, just install it as a normal user.
@@ -63,11 +75,17 @@ NOTE: Do not use ``sudo`` to install Anaconda, just install it as a normal user.
 This also installs Cython and CFFI.
 
 ## SWIG
-Now that Anaconda is installed, you can use the included **conda** package manager to install SWIG.  Do
+If Anaconda is installed, you can use the included **conda** package manager to install SWIG.  Do
 the following in a command-line terminal:
 
 ```bash
 conda install swig
+```
+
+Alternatively, on macOS you can use the Homebrew package manager to install SWIG:
+
+```shell script
+brew install swig
 ```
 
 ## PyPy

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ means that code ran twice as fast as the pure Python version.
 | CFFI               |  6      |
 | Python             |  1      |
 
-NOTE: These numbers were measured on a 2013 15" Mac Book Pro using Python 3.6 via Anaconda distro
-with the latest versions of all tools installed using the conda package manager.
+NOTE: These numbers were originally measured on a 2013 15" Mac Book Pro using Python 3.6 via Anaconda distro
+with the latest versions of all tools installed using the conda package manager.  I have more recently measured
+using a Python 3.7 virtual environment via [Pipenv](https://github.com/pypa/pipenv) and confirmed that they
+stayed approximately the same and relative rankings in terms of performance are identical.
 
 The Fibonacci example presented here is pretty trivial.  Your mileage may vary depending on your
 application.  But overall these performance measurements are fairly representative of what you
@@ -154,6 +156,13 @@ performance improvements.
 pybind11 struggles with easy cross-platform compatibility and its performance is worse than SWIG, but it is more of a
 pain to use than SWIG.  So I'd recommend staying away from it for now unless you are looking to embed Python code within
 a C++ project on Windows.
+
+## Updates for 2019
+Recent re-evaluation of all these options firmly confirms my original conclusions.  `Cython` and `SWIG` are both awesome 
+with distinct tradeoffs.  The combination of `PyPy` + `CFFI` is attractive and shows a lot of potential.  While the 
+cross-platform compatibility issues previously seen with `pybind11` appear to have been resolved, I still can't see a
+use case for which it would be superior to one of the other options; but it has a ton of stars on GitHub so perhaps I 
+am missing something?
 
 # Running Example Code Yourself
 For information on getting all of the necessary prerequisites installed, see


### PR DESCRIPTION
Added a Pipfile for easily installing `cffi`, `cython`, and `pybind11` using Pipenv.

Also added updates to the documentation after re-running the performance comparison examples using Python 3.7 in a Pipenv virtual env.